### PR TITLE
feat: Add area-based window control

### DIFF
--- a/AREA_BASED_WINDOW_CONTROL.md
+++ b/AREA_BASED_WINDOW_CONTROL.md
@@ -1,0 +1,133 @@
+# Area-Based Window Control Implementation
+
+## Changes Implemented
+
+### 1. const.py
+- Added `CONF_WINDOW_SENSORS` for window sensor list
+- Added `CONF_WINDOW_OPEN_DELAY` for open delay
+- Added `DEFAULT_WINDOW_OPEN_DELAY = 15`
+- Added `WindowControlMode.AREA_BASED` as new mode
+
+### 2. window_control.py
+New implementation with:
+- **Area-based mode**: Tracks each window individually
+- **Area logic**: Uses `entity_registry` and `area_registry` to identify areas of windows and thermostats
+- **Granular control**: Turns off only members in the same area as the opened window
+- **Multi-window**: Handles multiple open windows simultaneously
+- **Backward compatibility**: Maintains legacy logic for room/zone sensors
+
+#### How it works:
+1. When a window opens → identifies its area
+2. Finds all group members in the same area
+3. Turns off only those members (after configured delay)
+4. When window closes → restores only members that were turned off by that window
+5. If multiple windows are open in the same area, restoration happens only when all are closed
+
+### 3. config_flow.py
+- Added imports for `CONF_WINDOW_SENSORS` and `CONF_WINDOW_OPEN_DELAY`
+- Modified `async_step_window_control()` to show dynamic configuration:
+  - If `window_mode = area_based` → shows multiple selector for windows
+  - If `window_mode = on` → shows legacy configuration (room/zone sensor)
+
+### 4. service_call.py
+- Added optional `entity_ids` parameter to:
+  - `call_immediate()`
+  - `_execute_calls()`
+  - `_generate_calls()`
+  - `_get_unsynced_entities()`
+- Allows targeting specific members instead of entire group
+
+## Steps to Complete
+
+### 1. Add translations in strings.json
+Add under `config.step.window_control.data`:
+```json
+"window_sensors": "Window Sensors (Area-based)",
+"window_open_delay": "Window Open Delay"
+```
+
+Add under `config.step.window_control.data_description`:
+```json
+"window_sensors": "Select all window sensors to monitor. When a window opens, only climate devices in the same area will be turned off.",
+"window_open_delay": "Time to wait before turning off heating after a window opens."
+```
+
+Add under `selector.window_mode.options`:
+```json
+"area_based": "Area-based (automatic zone detection)"
+```
+
+### 2. Update __init__.py
+Add to exported constants:
+```python
+CONF_WINDOW_SENSORS,
+CONF_WINDOW_OPEN_DELAY,
+DEFAULT_WINDOW_OPEN_DELAY,
+```
+
+### 3. Increment VERSION in config_flow.py
+```python
+VERSION = 7  # Was 6
+```
+
+### 4. Add migration in __init__.py
+In `async_migrate_entry()` method, add:
+```python
+if config_entry.version < 7:
+    # Migrate to version 7 - area-based window control
+    new_options = {**config_entry.options}
+    
+    # If window control was enabled, keep legacy mode
+    if new_options.get(CONF_WINDOW_MODE) == WindowControlMode.ON:
+        # Keep existing configuration as-is (legacy mode)
+        pass
+    
+    config_entry.version = 7
+    hass.config_entries.async_update_entry(config_entry, options=new_options)
+    _LOGGER.info("Migrated %s to version %s", config_entry.title, config_entry.version)
+```
+
+## How to Use
+
+### Helper Configuration
+
+1. Go to **Settings** > **Devices & Services** > **Helpers**
+2. Find your Climate Group Helper
+3. Click **Configure** > **Window Control**
+4. Select **Window Mode**: `area_based`
+5. Select all windows to monitor in **Window Sensors**
+6. Configure **Window Open Delay** (default: 15s)
+7. Configure **Close Delay** (default: 30s)
+
+### Requirements
+
+- **Areas configured**: Windows and thermostats must be assigned to areas in Home Assistant
+- **Same area name**: Window and thermostat must be in the same area to be associated
+- If an entity has no assigned area, the system tries to use the device's area
+
+### Example
+
+**Setup:**
+- Area "Living Room": `binary_sensor.living_room_window`, `climate.living_room_thermostat`
+- Area "Bedroom": `binary_sensor.bedroom_window`, `climate.bedroom_thermostat`
+- Group: includes both thermostats
+
+**Behavior:**
+1. Open `living_room_window` → only `living_room_thermostat` turns off
+2. Open `bedroom_window` → only `bedroom_thermostat` turns off
+3. Close `living_room_window` → only `living_room_thermostat` turns back on
+4. Close `bedroom_window` → only `bedroom_thermostat` turns back on
+
+## Testing
+
+1. Verify areas are configured correctly
+2. Test single window open/close
+3. Test multiple windows in different areas
+4. Test multiple windows in same area
+5. Check logs for debug: `custom_components.climate_group_helper: debug`
+
+## Notes
+
+- Legacy mode (room/zone sensor) continues to work for backward compatibility
+- If `window_mode = area_based` but no sensors configured, control is disabled
+- If an entity has no area, it's ignored by area-based control

--- a/custom_components/climate_group_helper/const.py
+++ b/custom_components/climate_group_helper/const.py
@@ -68,9 +68,12 @@ CONF_ZONE_SENSOR = "zone_sensor"
 CONF_ROOM_OPEN_DELAY = "room_open_delay"
 CONF_ZONE_OPEN_DELAY = "zone_open_delay"
 CONF_CLOSE_DELAY = "close_delay"
+CONF_WINDOW_SENSORS = "window_sensors"  # New: list of window sensors
+CONF_WINDOW_OPEN_DELAY = "window_open_delay"  # New: delay before turning off
 DEFAULT_ROOM_OPEN_DELAY = 15
 DEFAULT_ZONE_OPEN_DELAY = 300
 DEFAULT_CLOSE_DELAY = 30
+DEFAULT_WINDOW_OPEN_DELAY = 15
 
 # Schedule options
 CONF_SCHEDULE_ENTITY = "schedule_entity"
@@ -111,6 +114,7 @@ class WindowControlMode(StrEnum):
 
     OFF = "off"
     ON = "on"
+    AREA_BASED = "area_based"  # New: area-based control
 
 
 # Extra attribute keys

--- a/custom_components/climate_group_helper/window_control.py
+++ b/custom_components/climate_group_helper/window_control.py
@@ -9,17 +9,21 @@ from homeassistant.components.climate import HVACMode
 from homeassistant.const import STATE_ON, STATE_OPEN, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers.event import async_call_later, async_track_state_change_event
+from homeassistant.helpers import entity_registry as er, area_registry as ar
 
 from .const import (
     CONF_CLOSE_DELAY,
     CONF_ROOM_OPEN_DELAY,
     CONF_ROOM_SENSOR,
     CONF_WINDOW_MODE,
+    CONF_WINDOW_SENSORS,
+    CONF_WINDOW_OPEN_DELAY,
     CONF_ZONE_OPEN_DELAY,
     CONF_ZONE_SENSOR,
     DEFAULT_CLOSE_DELAY,
     DEFAULT_ROOM_OPEN_DELAY,
     DEFAULT_ZONE_OPEN_DELAY,
+    DEFAULT_WINDOW_OPEN_DELAY,
     WindowControlMode,
 )
 
@@ -34,52 +38,82 @@ WINDOW_OPEN = "open"
 
 
 class WindowControlHandler:
-    """Manages dual-timer Room+Zone window control logic."""
+    """Manages window control logic with area-based support."""
 
     def __init__(self, group: ClimateGroup) -> None:
         """Initialize the window control handler."""
         self._group = group
-        self._timer_cancel: Any = None
+        self._timer_cancel: dict[str, Any] = {}  # Per-window timers
         self._unsub_listener = None
 
         self._window_control_mode = self._group.config.get(CONF_WINDOW_MODE, WindowControlMode.OFF)
-        self._control_state = WINDOW_CLOSE
         
-        # Configuration
+        # Legacy configuration (backward compatibility)
         self._room_sensor = group.config.get(CONF_ROOM_SENSOR)
         self._zone_sensor = group.config.get(CONF_ZONE_SENSOR)
         self._room_delay = group.config.get(CONF_ROOM_OPEN_DELAY, DEFAULT_ROOM_OPEN_DELAY)
         self._zone_delay = group.config.get(CONF_ZONE_OPEN_DELAY, DEFAULT_ZONE_OPEN_DELAY)
         self._close_delay = group.config.get(CONF_CLOSE_DELAY, DEFAULT_CLOSE_DELAY)
 
+        # New area-based configuration
+        self._window_sensors = group.config.get(CONF_WINDOW_SENSORS, [])
+        self._window_open_delay = group.config.get(CONF_WINDOW_OPEN_DELAY, DEFAULT_WINDOW_OPEN_DELAY)
+        
+        # Track which members are turned off by which windows
+        self._affected_members: dict[str, set[str]] = {}  # window_id -> set of member entity_ids
+
+        # Legacy state tracking
+        self._control_state = WINDOW_CLOSE
         self._room_open = False
         self._zone_open = False
         self._room_last_changed = None
         self._zone_last_changed = None
 
         _LOGGER.debug(
-            "[%s] WindowControl initialized. (room: %s.open_delay: %ds), (zone: %s.open_delay: %ds), (room/zone: close_delay: %ds)",
-            group.entity_id, self._room_sensor, self._room_delay, self._zone_sensor, self._zone_delay, self._close_delay)
+            "[%s] WindowControl initialized. Mode: %s, Windows: %s",
+            group.entity_id, self._window_control_mode, self._window_sensors)
 
     @property
     def force_off(self) -> bool:
-        """Return whether window control is active."""
+        """Return whether window control is active (legacy mode)."""
+        if self._window_control_mode == WindowControlMode.AREA_BASED:
+            return len(self._affected_members) > 0
         return self._control_state == WINDOW_OPEN
 
     def async_teardown(self) -> None:
         """Unsubscribe from sensors and cancel timers."""
-        self._cancel_timer()
+        for cancel_func in self._timer_cancel.values():
+            if cancel_func:
+                cancel_func()
+        self._timer_cancel.clear()
+        
         if self._unsub_listener:
             self._unsub_listener()
             self._unsub_listener = None
 
     async def async_setup(self) -> None:
         """Subscribe to window sensor state changes."""
-        # Check if window control is enabled
         if self._window_control_mode == WindowControlMode.OFF:
-            _LOGGER.debug("[%s] Window control is disabled (window_mode=%s)", self._group.entity_id, self._window_control_mode)
+            _LOGGER.debug("[%s] Window control is disabled", self._group.entity_id)
             return
 
+        # Area-based mode
+        if self._window_control_mode == WindowControlMode.AREA_BASED:
+            if not self._window_sensors:
+                _LOGGER.warning("[%s] Area-based window control enabled but no sensors configured", self._group.entity_id)
+                return
+            
+            self._unsub_listener = async_track_state_change_event(
+                self._group.hass, self._window_sensors, self._area_based_listener
+            )
+            _LOGGER.debug("[%s] Area-based window control subscribed to: %s", self._group.entity_id, self._window_sensors)
+            
+            # Check initial state
+            for window_id in self._window_sensors:
+                await self._check_window_state(window_id)
+            return
+
+        # Legacy mode
         sensors_to_track = []
         if self._room_sensor:
             sensors_to_track.append(self._room_sensor)
@@ -88,14 +122,13 @@ class WindowControlHandler:
         if not sensors_to_track:
             return
 
-        # Subscribe to window sensor state changes
         self._unsub_listener = async_track_state_change_event(
             self._group.hass, sensors_to_track, self._state_change_listener,
         )
 
         _LOGGER.debug("[%s] Window control subscribed to: %s", self._group.entity_id, sensors_to_track)
 
-        # Check initial state
+        # Check initial state (legacy)
         result = self._window_control_logic()
         if result:
             mode, delay = result
@@ -104,7 +137,142 @@ class WindowControlHandler:
             if delay <= 0:
                 self._group.hass.async_create_task(self._execute_action(mode))
             else:
-                self._timer_cancel = async_call_later(self._group.hass, delay, self._timer_expired)
+                self._timer_cancel["legacy"] = async_call_later(self._group.hass, delay, self._timer_expired)
+
+    @callback
+    def _area_based_listener(self, event: Event[EventStateChangedData]) -> None:
+        """Handle window sensor event in area-based mode."""
+        window_id = event.data.get("entity_id")
+        if not window_id:
+            return
+        
+        _LOGGER.debug("[%s] Window sensor event: %s", self._group.entity_id, window_id)
+        self._group.hass.async_create_task(self._check_window_state(window_id))
+
+    async def _check_window_state(self, window_id: str) -> None:
+        """Check window state and control members in the same area."""
+        state = self._group.hass.states.get(window_id)
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+
+        is_open = state.state in (STATE_ON, STATE_OPEN)
+        
+        if is_open:
+            # Window opened - schedule turn off for members in same area
+            time_since_change = time.time() - state.last_changed.timestamp()
+            delay = max(self._window_open_delay - time_since_change, 0)
+            
+            if delay > 0:
+                _LOGGER.debug("[%s] Window %s opened, scheduling turn off in %.1fs", 
+                             self._group.entity_id, window_id, delay)
+                # Cancel existing timer for this window
+                if window_id in self._timer_cancel and self._timer_cancel[window_id]:
+                    self._timer_cancel[window_id]()
+                
+                self._timer_cancel[window_id] = async_call_later(
+                    self._group.hass, delay, 
+                    lambda _: self._group.hass.async_create_task(self._turn_off_area_members(window_id))
+                )
+            else:
+                await self._turn_off_area_members(window_id)
+        else:
+            # Window closed - restore members
+            if window_id in self._timer_cancel and self._timer_cancel[window_id]:
+                self._timer_cancel[window_id]()
+                del self._timer_cancel[window_id]
+            
+            delay = self._close_delay
+            _LOGGER.debug("[%s] Window %s closed, scheduling restore in %.1fs", 
+                         self._group.entity_id, window_id, delay)
+            
+            self._timer_cancel[f"{window_id}_close"] = async_call_later(
+                self._group.hass, delay,
+                lambda _: self._group.hass.async_create_task(self._restore_area_members(window_id))
+            )
+
+    async def _turn_off_area_members(self, window_id: str) -> None:
+        """Turn off climate members in the same area as the window."""
+        window_area = self._get_entity_area(window_id)
+        if not window_area:
+            _LOGGER.warning("[%s] Cannot determine area for window %s", self._group.entity_id, window_id)
+            return
+
+        affected = set()
+        for member_id in self._group.config.get("entities", []):
+            member_area = self._get_entity_area(member_id)
+            if member_area == window_area:
+                affected.add(member_id)
+        
+        if not affected:
+            _LOGGER.debug("[%s] No members in area '%s' for window %s", 
+                         self._group.entity_id, window_area, window_id)
+            return
+
+        self._affected_members[window_id] = affected
+        
+        _LOGGER.info("[%s] Window %s opened in area '%s', turning off members: %s", 
+                    self._group.entity_id, window_id, window_area, affected)
+        
+        # Turn off affected members
+        for member_id in affected:
+            await self._group.hass.services.async_call(
+                "climate", "set_hvac_mode",
+                {"entity_id": member_id, "hvac_mode": HVACMode.OFF},
+                blocking=False,
+                context=self._group.hass.context
+            )
+
+    async def _restore_area_members(self, window_id: str) -> None:
+        """Restore climate members that were turned off by this window."""
+        if window_id not in self._affected_members:
+            return
+
+        affected = self._affected_members.pop(window_id)
+        
+        # Check if any other window is still affecting these members
+        still_affected = set()
+        for other_window, other_members in self._affected_members.items():
+            still_affected.update(other_members)
+        
+        to_restore = affected - still_affected
+        
+        if not to_restore:
+            _LOGGER.debug("[%s] Window %s closed, but members still affected by other windows", 
+                         self._group.entity_id, window_id)
+            return
+
+        _LOGGER.info("[%s] Window %s closed, restoring members: %s", 
+                    self._group.entity_id, window_id, to_restore)
+        
+        # Restore target state for these members
+        await self._group.service_call_handler.call_immediate(
+            context_id="window_control",
+            entity_ids=list(to_restore)
+        )
+
+    def _get_entity_area(self, entity_id: str) -> str | None:
+        """Get the area ID for an entity."""
+        ent_reg = er.async_get(self._group.hass)
+        entity_entry = ent_reg.async_get(entity_id)
+        
+        if not entity_entry:
+            return None
+        
+        # Try entity's area first
+        if entity_entry.area_id:
+            return entity_entry.area_id
+        
+        # Try device's area
+        if entity_entry.device_id:
+            from homeassistant.helpers import device_registry as dr
+            dev_reg = dr.async_get(self._group.hass)
+            device_entry = dev_reg.async_get(entity_entry.device_id)
+            if device_entry and device_entry.area_id:
+                return device_entry.area_id
+        
+        return None
+
+    # Legacy methods below (for backward compatibility)
 
     @callback
     def _state_change_listener(self, event: Event[EventStateChangedData]) -> None:
@@ -118,80 +286,59 @@ class WindowControlHandler:
             return
                 
         mode, delay = result
-        self._cancel_timer()
+        if "legacy" in self._timer_cancel and self._timer_cancel["legacy"]:
+            self._timer_cancel["legacy"]()
+            del self._timer_cancel["legacy"]
 
-        # Skip timer if no action needed (HVAC already in desired state)
         current_hvac = self._group.hvac_mode
         if mode == WINDOW_OPEN and current_hvac == HVACMode.OFF:
             _LOGGER.debug("[%s] HVAC is already OFF, skipping timer", self._group.entity_id)
-            self._control_state = WINDOW_OPEN  # Clear blocking mode
+            self._control_state = WINDOW_OPEN
             return
-
         elif mode == WINDOW_CLOSE and current_hvac != HVACMode.OFF:
             _LOGGER.debug("[%s] HVAC is already ON, skipping timer", self._group.entity_id)
-            self._control_state = WINDOW_CLOSE  # Clear blocking mode
+            self._control_state = WINDOW_CLOSE
             return
         
         if delay > 0:
             _LOGGER.debug("[%s] Scheduling action in %.1fs", self._group.entity_id, delay)
-            self._timer_cancel = async_call_later(self._group.hass, delay, self._timer_expired)
+            self._timer_cancel["legacy"] = async_call_later(self._group.hass, delay, self._timer_expired)
         else:
             self._group.hass.async_create_task(self._execute_action(mode))
 
     @callback
     def _timer_expired(self, now: Any) -> None:
         """Timer callback – recalculate and execute current action."""
-        self._timer_cancel = None
+        if "legacy" in self._timer_cancel:
+            del self._timer_cancel["legacy"]
         mode, _ = self._window_control_logic()
         if mode:
             self._group.hass.async_create_task(self._execute_action(mode))
 
-    def _cancel_timer(self) -> None:
-        """Cancel any pending timer."""
-        if self._timer_cancel:
-            self._timer_cancel()
-            self._timer_cancel = None
-            _LOGGER.debug("[%s] Timer cancelled", self._group.entity_id)
-
     async def _execute_action(self, mode: str) -> None:
-        """Execute heating ON/OFF action.
-        
-        Window Control does NOT modify target_state:
-        - OPEN: Forces members OFF via call_hvac_off (target_state preserved)
-        - CLOSE: Restores members to target_state via call_immediate
-        """
-        # Update control state first
+        """Execute heating ON/OFF action (legacy mode)."""
         self._control_state = mode
 
         if mode == WINDOW_OPEN:
-            # Turn HVAC OFF
             if self._group.hvac_mode != HVACMode.OFF:
                 _LOGGER.debug("[%s] Window opened, turning HVAC OFF", self._group.entity_id)
                 await self._group.service_call_handler.call_hvac_off(context_id="window_control")
             else:
                 _LOGGER.debug("[%s] Window opened, HVAC already OFF in target_state", self._group.entity_id)
-
         elif mode == WINDOW_CLOSE:
-            # Restore target_state
             _LOGGER.debug("[%s] Window closed, restoring target_state", self._group.entity_id)
             await self._group.service_call_handler.call_immediate(context_id="window_control")
 
     def _window_control_logic(self) -> tuple[str, float] | None:
-        """This method implements the core logic from the Window Heating Control blueprint.
-
-        Return the control mode and the timer delay.
-        Return None if no sensors are configured.
-        """
+        """Legacy window control logic."""
         self._room_open = None
         self._zone_open = None
         self._room_last_changed = None
         self._zone_last_changed = None
 
-        # If no sensors are configured, return None
         if not self._room_sensor and not self._zone_sensor:
             return None
 
-        # If no room sensor is configured, room is always closed
         if self._room_sensor and (state := self._group.hass.states.get(self._room_sensor)):
             self._room_open = state.state in (STATE_ON, STATE_OPEN)
             self._room_last_changed = time.time() - state.last_changed.timestamp()
@@ -199,7 +346,6 @@ class WindowControlHandler:
             self._room_open = False
             self._room_last_changed = float("inf")
 
-        # If no zone sensor is configured, use room sensor state
         if self._zone_sensor and (state := self._group.hass.states.get(self._zone_sensor)):
             self._zone_open = state.state in (STATE_ON, STATE_OPEN) or self._room_open
             self._zone_last_changed = time.time() - state.last_changed.timestamp()
@@ -207,17 +353,14 @@ class WindowControlHandler:
             self._zone_open = self._room_open
             self._zone_last_changed = self._room_last_changed
 
-        # Calculate timers
         timer_room_open = max(self._room_delay - self._room_last_changed, 0) if self._room_open else self._room_delay
         timer_zone_open = max(self._zone_delay - self._zone_last_changed, 0) if self._zone_open else self._zone_delay
         timer_zone_close = max(self._close_delay - self._zone_last_changed, 0) if not self._zone_open else self._close_delay
 
-        # Calculate delays
         delay_room_open = min(timer_room_open, timer_zone_open) if self._room_open else None
         delay_zone_open = timer_zone_open if self._zone_open and not self._room_open else None
         delay_zone_close = timer_zone_close if not self._zone_open or not self._room_open else None
 
-        # Calculate mode and delay
         mode = WINDOW_OPEN if self._zone_open or self._room_open else WINDOW_CLOSE
         delay = (delay_room_open or delay_zone_open or delay_zone_close) or 0
 


### PR DESCRIPTION
- Add CONF_WINDOW_SENSORS for multiple window sensor selection
- Add CONF_WINDOW_OPEN_DELAY configuration option
- Add WindowControlMode.AREA_BASED mode
- Implement area-based window control logic using entity/area registries
- Turn off only climate members in the same area as opened window
- Support multiple windows with per-window tracking
- Maintain backward compatibility with legacy room/zone sensor mode
- Add entity_ids parameter to service_call methods for granular control
- Add dynamic UI in config_flow based on selected window mode